### PR TITLE
Fix cursor option

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -6,7 +6,7 @@ foreground    = "#{{base05-hex}}"
 background    = "#{{base00-hex}}"
 cursor_bg     = "#{{base05-hex}}"
 cursor_border = "#{{base05-hex}}"
-cursor        = "#{{base05-hex}}"
+cursor_fg     = "#{{base00-hex}}"
 selection_bg  = "#{{base05-hex}}"
 selection_fg  = "#{{base00-hex}}"
 


### PR DESCRIPTION
`cursor` is not a valid option when loading the toml in wezterm.
Wezterm therefore throws a config error when launched.

I have changed it to `cursor_fg` and the value to match `background`.
This seems to produce the expected colorscheme.